### PR TITLE
add docker file for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Run `docker build .` from this folder to test
+FROM nickgryg/alpine-pandas
+
+# for shapely
+RUN sh -c "apk add --no-cache \
+            gcc \
+            libc-dev \
+            geos-dev && \
+            pip install shapely"
+
+COPY . .
+# for pdf creation
+RUN apk add wkhtmltopdf
+RUN sh -c "pip install -e downloader && \
+    pip install -e scraper && \
+    python -m erddap_downloader downloader/test/test_query.json && \
+    unzip *zip"
+
+# TODO get this line working and add after the unzip line
+#python -c ""import pandas,glob;pandas.read_csv(glob.glob('*.csv')[0]);"""

--- a/scraper/erddap_scraper/ERDDAP.py
+++ b/scraper/erddap_scraper/ERDDAP.py
@@ -5,7 +5,6 @@
 import requests
 import json
 import re
-from bs4 import BeautifulSoup
 from .setup_logging import setup_logging
 
 logger = setup_logging()
@@ -108,45 +107,3 @@ class ERDDAP(object):
             'variables': vars
         }
         return metadata
-
-    def scrape_contact_from_jsonld(self):
-        '''
-        TODO we may not end up needing this data!
-
-        Scrape the json-ld from html of <erddap_url>/info/index.html
-
-        This is an example of the data produced:
-        {
-          "@type": "Organization",
-          "name": "Hakai Institute",
-          "address": {
-            "@type": "PostalAddress",
-            "addressCountry": "Canada",
-            "addressLocality": "PO Box 309, Heriot Bay",
-            "addressRegion": "BC",
-            "postalCode": "V0P 1H0"
-          },
-          "telephone": "5555555555",
-          "email": "admin@hakai.org",
-          "sameAs": "http://hakai.org"
-        }
-
-        '''
-        url_add = "/info/index.html"
-        # the json-ld is embedded inside the source html
-        html = self.session.get(self.url + url_add).text
-        soup = BeautifulSoup(html, "html5lib")
-        # find the json-ld bit and strip the <script> tags
-        jsonld_string = soup.find('script',
-                                  {"type": "application/ld+json"}).text.strip()
-        # parse the json string to a dict
-        jsonld = json.loads(jsonld_string)
-        publisher = jsonld['publisher']
-
-        parsed = {
-            'telephone': publisher["telephone"],
-            'email': publisher["email"],
-            'address': publisher["address"]
-        }
-
-        return parsed


### PR DESCRIPTION
adds a docker test for the downloader. The test isn't successful yet so that would be something to work towards

run it with `docker build .`

Also removes the `bs4` dependancy and some old code from another project that used it

Note that it runs the downloader like this: 
`python -m erddap_downloader downloader/test/test_query.json`
and then expects a zip file in the folder it was run from, and at least one CSV in that zip file that can be read by Pandas (Loading it in Pandas confirms it is a CSV, not an error message)
