### PR TITLE
save download errors to DB

### DIFF
--- a/ceda-web-api/routes/download.js
+++ b/ceda-web-api/routes/download.js
@@ -7,8 +7,6 @@ const db = require("../db");
 const createDBFilter = require("../utils/dbFilter");
 const { eovGrouping } = require("../utils/grouping");
 
-/* GET /tiles/:z/:x/:y.mvt */
-/* Retreive a vector tile by tileid */
 router.get("/", async (req, res) => {
   const {
     timeMin,
@@ -24,8 +22,6 @@ router.get("/", async (req, res) => {
     polygon,
   } = req.query;
 
-  console.log("download");
-
   const filters = createDBFilter(req.query);
   // const wkt
   const wktPolygon =
@@ -34,9 +30,7 @@ router.get("/", async (req, res) => {
       .map(([lat, lon]) => `${lat} ${lon}`)
       .join() +
     "))";
-  console.log("wktPolygon", wktPolygon);
 
-  // TODO add depth
   const SQL = `
         with profiles_subset as (
         select d.erddap_url, d.dataset_id,d.profile_variable,d.cdm_data_type, d.ckan_record->>'id' ckan_id, 'https://catalogue.cioos.ca/dataset/' ckan_url  FROM cioos_api.profiles p
@@ -76,6 +70,7 @@ router.get("/", async (req, res) => {
 
     // add to the jobs queue
     await db("cioos_api.download_jobs").insert({
+      email: email,
       downloader_input: downloaderInput,
     });
 

--- a/download_scheduler/download_email.py
+++ b/download_scheduler/download_email.py
@@ -1,7 +1,8 @@
 import subprocess
 
-def send_email(email,message,subject):
-    line=f"echo '{message}' | mail -s '{subject}' {email}"
+
+def send_email(email, message, subject):
+    line = f"echo '{message}' | mail -s '{subject}' {email}"
     print(line)
-    res=subprocess.run(["sh","-c", line])
+    res = subprocess.run(["sh", "-c", line])
     print(res)

--- a/downloader/erddap_downloader/downloader_wrapper.py
+++ b/downloader/erddap_downloader/downloader_wrapper.py
@@ -28,7 +28,7 @@ def parallel_downloader(json_blob=None, output_folder="", create_pdf=False):
     
     # output_folder will never be created in production, just for development
     os.makedirs(output_folder,exist_ok=True)
-
+    
     for filtered_result in json_blob["cache_filtered"]:
         erddap_url = filtered_result["erddap_url"]
         ckan_url = filtered_result["ckan_url"]
@@ -43,21 +43,11 @@ def parallel_downloader(json_blob=None, output_folder="", create_pdf=False):
                 ),
             )
             print("creating pdf file ...")
-            pid = Process(
-                target=download_ckan_pdf,
-                args=(ckan_url, ckan_id, ckan_filename),
-            )
-            pid.start()
-            pid.join()
-
+            download_ckan_pdf(ckan_url, ckan_id, ckan_filename)
+            
+        download_erddap.get_dataset(json_blob, temp_folder)
         # call jessy's code here to download data from erddap
-        blob = json_blob
-        blob["cache_filtered"] = [filtered_result]
-        pid = Process(
-            target=download_erddap.get_dataset, args=(blob, temp_folder)
-        )
-        pid.start()
-        pid.join()
+        
     # zip files in folder
     zip_full_path = os.path.join(output_folder,zip_filename)
     print("Writing zip ",zip_full_path)


### PR DESCRIPTION
This improves download job error reporting. Jobs that fail are now given status "failed" and the complete error message is recorded. Parallel downloading was sacrificed for now to achieve this for the MVP.

Fixes #79