### PR TITLE
change hex colors/opacity

### DIFF
--- a/frontend/src/components/Map/Map.js
+++ b/frontend/src/components/Map/Map.js
@@ -125,13 +125,13 @@ export default class CIOOSMap extends React.Component {
         "source-layer": "internal-layer-name",
 
         paint: {
-          "fill-opacity": 0.5,
+          "fill-opacity": 0.7,
           "fill-color": {
             property: "count",
             stops: [
-              [0, config.colorScale[0]],
-              [50, config.colorScale[1]],
-              [100, config.colorScale[2]],
+              [0, "rgb(251, 231, 35)"],
+              [50, "rgb(37, 171, 130)"],
+              [100, "rgb(68, 1, 84)"],
             ],
           },
         },


### PR DESCRIPTION
I am PR'ing this change because our current colours make single-point organizations invisible, which makes it seem like the organization selector is broken. 

These colours were suggested by @Mbrownshoes at some point, though I dunno if he's still into them, I'm not attached to these colours, just anything that makes a single point hexagon visible

![Screen Shot 2021-06-24 at 7 06 38 PM](https://user-images.githubusercontent.com/26209011/123357919-57487180-d51f-11eb-94c2-897493a77445.png)
