### PR TITLE
only let registered users download

### DIFF
--- a/ceda-web-api/routes/download.js
+++ b/ceda-web-api/routes/download.js
@@ -7,7 +7,7 @@ const db = require("../db");
 const createDBFilter = require("../utils/dbFilter");
 const { eovGrouping } = require("../utils/grouping");
 
-router.get("/", async (req, res) => {
+router.get("/", async (req, res, next) => {
   const {
     timeMin,
     timeMax,
@@ -44,6 +44,16 @@ router.get("/", async (req, res) => {
 
   console.log(SQL);
   let count = 0;
+
+  // Make sure they are a registered user
+  const allowedUsers = (await db("cioos_api.allowed_users")).map(
+    (e) => e.email
+  );
+  if (!allowedUsers.includes(email)) {
+    res.send(403);
+    return next();
+  }
+
   try {
     const tileRaw = await db.raw(SQL);
     const tile = tileRaw.rows[0];

--- a/ceda-web-api/routes/index.js
+++ b/ceda-web-api/routes/index.js
@@ -22,7 +22,7 @@ router.get("/organizations", async function (req, res, next) {
 });
 
 router.get("/jobs", async function (req, res, next) {
-  res.send(await db("cioos_api.download_jobs"));
+  res.send(await db("cioos_api.download_jobs").orderBy("time", "desc"));
 });
 
 /* GET home page. */

--- a/scraper/db/db.sql
+++ b/scraper/db/db.sql
@@ -49,7 +49,13 @@ CREATE TABLE cioos_api.cdm_data_type_override (
     erddap_url text,
     dataset_id text,
     cdm_data_type text
-);    
+);  
+
+DROP TABLE cioos_api.allowed_users;
+CREATE TABLE cioos_api.allowed_users (
+    pk SERIAL PRIMARY KEY,
+    email text UNIQUE
+);
 
 CREATE INDEX
   ON cioos_api.profiles


### PR DESCRIPTION
This PR adds an `allowed_users` table where we can control access to downloading at the API level. A 403 error is sent to the client when a non-registered user tries to download. 

Also snuck in sorting of the jobs list by time (see https://pac-dev2.cioos.org/ceda/jobs)