### PR TITLE
change pointQuery to group by dataset, add profile count route

### DIFF
--- a/ceda-web-api/routes/tiles.js
+++ b/ceda-web-api/routes/tiles.js
@@ -35,19 +35,19 @@ router.get("/:z/:x/:y.mvt", async (req, res) => {
         SELECT count(*) count, ${
           isHexGrid
             ? ""
-            : `(d.cdm_data_type = any(array[${typeStr}]))::integer pointtype,`
+            : `point_pk as pk, (d.cdm_data_type = any(array[${typeStr}]))::integer pointtype,`
         } p.${sqlQuery.geom_column} as geom from cioos_api.profiles p
         JOIN cioos_api.datasets d ON p.dataset_pk =d.pk 
        ${filters ? "WHERE " + filters : ""}
         ${
           isHexGrid
             ? `group by ${sqlQuery.geom_column}`
-            : "group by geom, cdm_data_type"
+            : "group by point_pk,geom, cdm_data_type"
         } ),
     te as (select ST_TileEnvelope(${z}, ${x}, ${y}) tile_envelope ),
     mvtgeom as (
       SELECT count,
-       ${isHexGrid ? "" : "pointtype,"}
+       ${isHexGrid ? "" : "pk,pointtype,"}
         ST_AsMVTGeom (
           relevent_points.geom,
           tile_envelope

--- a/ceda-web-api/utils/dbFilter.js
+++ b/ceda-web-api/utils/dbFilter.js
@@ -1,9 +1,8 @@
 const { eovGrouping, cdmDataTypeGrouping } = require("./grouping");
 // this is used by the tiler and the downloader routes
 const removeDuplicates = (arr) => [...new Set(arr)];
-
+const IMPOSSIBLE_FILTER = "1=0";
 function createDBFilter({
-  eovs,
   timeMin,
   timeMax,
   depthMin,
@@ -12,19 +11,20 @@ function createDBFilter({
   latMax,
   lonMin,
   lonMax,
-  organizations = "",
-  dataType = "return-no-data",
+  // These are comma separated lists
+  eovs,
+  organizations,
+  dataType,
 }) {
-  const eovsCommaSeparatedString =
-    removeDuplicates(
-      eovs
-        .split(",")
-        .map((eov) => eovGrouping[eov])
-        .flat()
-        .map((eov) => `'${eov}'`)
-    ).join() || "return-no-data";
+  if (!dataType || !eovs) return IMPOSSIBLE_FILTER;
 
-  const organizationsString = organizations.split(",").map((e) => `'${e}'`);
+  const eovsCommaSeparatedString = removeDuplicates(
+    eovs
+      .split(",")
+      .map((eov) => eovGrouping[eov])
+      .flat()
+      .map((eov) => `'${eov}'`)
+  ).join();
 
   const pointTypeCommaSeparatedString =
     dataType
@@ -41,19 +41,21 @@ function createDBFilter({
 
   if (latMin) filters.push(`p.latitude_min >= '${latMin}'`);
   if (latMax) filters.push(`p.latitude_max < '${latMax}'`);
+
   if (lonMin) filters.push(`p.longitude_min >= '${lonMin}'`);
   if (lonMax) filters.push(`p.longitude_max < '${lonMax}'`);
-
-  if (organizations)
-    filters.push(`organization_pks && array[${organizationsString}]`);
 
   // disabled until we get depth data into the database
   if (depthMin) filters.push(`p.depth_min >= ${depthMin}`);
   if (depthMax) filters.push(`p.depth_max < ${depthMax}`);
 
+  if (organizations) {
+    const organizationsString = organizations.split(",").map((e) => `'${e}'`);
+    filters.push(`organization_pks && array[${organizationsString}]`);
+  }
   filters.push(`cdm_data_type = any(array[${pointTypeCommaSeparatedString}])`);
-
   filters.push(`eovs && array[${eovsCommaSeparatedString}]`);
+
   return filters.join(" AND \n");
 }
 


### PR DESCRIPTION
Some changes to support @JorinHakai 's work with dataset/profile hover text. Also adds an endpoint for profiles count based on the filter. Some example queries that use these routes: 

https://pac-dev2.cioos.org/ceda/pointQuery/71383

https://pac-dev2.cioos.org/ceda/profilesCount?timeMin=1900-01-01&timeMax=2021-07-06&depthMax=12000&eovs=carbon,currents,nutrients,salinity,temperature&organizations=2,3,4,7,12,13,14&dataType=casts,fixedStations