### PR TITLE
Fix issue with Failed Estimator

### DIFF
--- a/scraper/erddap_estimate/__main__.py
+++ b/scraper/erddap_estimate/__main__.py
@@ -132,7 +132,10 @@ def standard_name_from_eovs(eovs: list):
     """
     standard_names = set()
     for eov in eovs:
-        standard_names = standard_names.union(eovs_to_standard_name[eov])
+        if eov in eovs_to_standard_name:
+            standard_names = standard_names.union(eovs_to_standard_name[eov])
+        else:
+            warnings.warn(f"EOV {eov} is unavailable", UserWarning)
     return standard_names
 
 


### PR DESCRIPTION
This PR stopped early the estimator if no profiles is retrieved from a specific query. 

It also correct for a small fix related to the mapping of the EOVs to standard_names