### PR TITLE
Add a few missing mapping from goos to cf

### DIFF
--- a/scraper/erddap_scraper/eovs_to_standard_name.json
+++ b/scraper/erddap_scraper/eovs_to_standard_name.json
@@ -9,7 +9,11 @@
     "mole_concentration_of_dissolved_inorganic_carbon_in_sea_water",
     "ocean_mass_content_of_dissolved_inorganic_carbon",
     "partial_pressure_of_carbon_dioxide_in_sea_water",
-    "sea_water_ph_reported_on_total_scale"
+    "sea_water_ph_reported_on_total_scale",
+    "dry_atmosphere_mole_fraction_of_carbon_dioxide",
+    "fugacity_of_carbon_dioxide_in_sea_water",
+    "surface_partial_pressure_of_carbon_dioxide_in_air",
+    "surface_partial_pressure_of_carbon_dioxide_in_sea_water"
   ],
   "invertebrateAbundanceAndDistribution": [],
   "macroalgalCanopyCoverAndComposition": [],
@@ -28,10 +32,16 @@
     "moles_of_nitrate_and_nitrite_per_unit_mass_in_sea_water",
     "mole_concentration_of_nitrate_in_sea_water",
     "moles_of_nitrate_per_unit_mass_in_sea_water",
-    "moles_of_silicate_per_unit_mass_in_sea_water"
+    "moles_of_silicate_per_unit_mass_in_sea_water",
+    "mole_concentration_of_dissolved_inorganic_nitrogen_in_sea_water",
+    "mole_concentration_of_nitrite_in_sea_water"
   ],
   "oceanColour": [
-    "concentration_of_colored_dissolved_organic_matter_in_sea_water_expressed_as_equivalent_mass_fraction_of_quinine_sulfate_dihydrate"
+    "concentration_of_colored_dissolved_organic_matter_in_sea_water_expressed_as_equivalent_mass_fraction_of_quinine_sulfate_dihydrate",
+    "surface_downwelling_photosynthetic_photon_flux_in_air",
+    "surface_downwelling_photosynthetic_photon_flux_in_sea_water",
+    "surface_downwelling_shortwave_flux_in_air",
+    "downwelling_photosynthetic_photon_spherical_irradiance_in_sea_water"
   ],
   "oceanSound": [
     "sound_frequency",
@@ -132,7 +142,10 @@
     "upward_eastward_stress_at_sea_ice_base",
     "upward_northward_stress_at_sea_ice_base",
     "upward_x_stress_at_sea_ice_base",
-    "upward_y_stress_at_sea_ice_base"
+    "upward_y_stress_at_sea_ice_base",
+    "sea_surface_wave_directional_spread",
+    "sea_surface_wave_from_direction",
+    "sea_surface_wave_maximum_period"
   ],
   "oxygen": [
     "mass_concentration_of_oxygen_in_sea_water",
@@ -141,7 +154,9 @@
     "volume_fraction_of_oxygen_in_sea_water",
     "fractional_saturation_of_oxygen_in_sea_water"
   ],
-  "particulateMatter": ["sea_water_turbidity"],
+  "particulateMatter": [
+    "sea_water_turbidity"
+  ],
   "phytoplanktonBiomassAndDiversity": [
     "chlorophyll_concentration_in_sea_water",
     "concentration_of_chlorophyll",
@@ -155,7 +170,10 @@
     "mass_concentration_of_picophytoplankton_expressed_as_chlorophyll_in_sea_water",
     "mass_fraction_of_chlorophyll_a_in_sea_water"
   ],
-  "seaIce": ["sea_ice_draft", "sea_ice_thickness"],
+  "seaIce": [
+    "sea_ice_draft",
+    "sea_ice_thickness"
+  ],
   "seaState": [
     "sea_surface_swell_wave_period",
     "sea_surface_wave_directional_spread_at_variance_spectral_density_maximum",
@@ -186,7 +204,9 @@
     "sea_floor_depth_below_sea_surface",
     "sea_water_pressure_at_sea_floor"
   ],
-  "seaSurfaceSalinity": ["sea_surface_salinity"],
+  "seaSurfaceSalinity": [
+    "sea_surface_salinity"
+  ],
   "seaSurfaceTemperature": [
     "sea_surface_skin_temperature",
     "sea_surface_subskin_temperature"
@@ -209,7 +229,9 @@
     "northward_sea_water_velocity_assuming_no_tide",
     "northward_sea_water_velocity_due_to_tides",
     "northward_sea_water_velocity_at_sea_floor",
-    "upward_sea_water_velocity"
+    "upward_sea_water_velocity",
+    "sea_water_x_velocity",
+    "sea_water_y_velocity"
   ],
   "subSurfaceSalinity": [
     "sea_surface_salinity",
@@ -230,7 +252,8 @@
     "sea_water_potential_density",
     "sea_water_electrical_conductivity",
     "sea_water_density",
-    "sea_water_sigma_t"
+    "sea_water_sigma_t",
+    "sea_water_sigma_theta"
   ],
   "surfaceCurrents": [
     "surface_eastward_sea_water_velocity",


### PR DESCRIPTION
This is related to issue #242.

More mapping is added the terms left are either part of the following data type:
- flag 
- data quality
- atmospheric 
- platform specifc information 
- z component

# List left
Data Quality Types
* indicative_error_from_multibeam_acoustic_doppler_velocity_profiler_in_sea_water
* proportion_of_acceptable_signal_returns_from_acoustic_instrument_in_sea_water
* signal_intensity_from_multibeam_acoustic_doppler_velocity_sensor_in_sea_water
* volume_beam_attenuation_coefficient_of_radiative_flux_in_sea_water_corrected_for_pure_water_attenuance

Platform identifiers
* platform_id
* platform_name
* platform_orientation
* platform_pitch
* platform_roll
* platform_speed_wrt_sea_water

Atmospheric Variables
* reference_pressure
* relative_humidity
* surface_air_pressure
* tendency_of_air_pressure
* wind_from_direction
* wind_speed
* wind_speed_of_gust
* air_pressure
* air_pressure_at_mean_sea_level
* air_temperature
* dew_point_temperature

Location specific terms Z
* sea_water_pressure
* sea_water_pressure_due_to_sea_water
* height
* height_above_mean_sea_level




