### PR TITLE
Include phytoplankton cf terms into oceanColor as well

### DIFF
--- a/scraper/erddap_scraper/eovs_to_standard_name.json
+++ b/scraper/erddap_scraper/eovs_to_standard_name.json
@@ -41,7 +41,19 @@
     "surface_downwelling_photosynthetic_photon_flux_in_air",
     "surface_downwelling_photosynthetic_photon_flux_in_sea_water",
     "surface_downwelling_shortwave_flux_in_air",
-    "downwelling_photosynthetic_photon_spherical_irradiance_in_sea_water"
+    "downwelling_photosynthetic_photon_spherical_irradiance_in_sea_water",
+    "chlorophyll_concentration_in_sea_water",
+    "concentration_of_chlorophyll",
+    "concentration_of_chlorophyll_in_sea_water",
+    "mass_concentration_of_chlorophyll_in_sea_water",
+    "mass_concentration_of_chlorophyll_a_in_sea_water",
+    "mass_concentration_of_diatoms_expressed_as_chlorophyll_in_sea_water",
+    "mass_concentration_of_microphytoplankton_expressed_as_chlorophyll_in_sea_water",
+    "mass_concentration_of_miscellaneous_phytoplankton_expressed_as_chlorophyll_in_sea_water",
+    "mass_concentration_of_nanophytoplankton_expressed_as_chlorophyll_in_sea_water",
+    "mass_concentration_of_phytoplankton_expressed_as_chlorophyll_in_sea_water",
+    "mass_concentration_of_picophytoplankton_expressed_as_chlorophyll_in_sea_water",
+    "mass_fraction_of_chlorophyll_a_in_sea_water"
   ],
   "oceanSound": [
     "sound_frequency",


### PR DESCRIPTION
From GOOS EOV Ocean Color https://www.goosocean.org/components/com_oe/oe.php?task=download&id=39878&version=1.0&lang=1&format=1

Measurements of ocean colour (Table 1) include the intensity and spectral variability of light backscattered
from below the ocean surface, vertical profiles of the colour of water, and measures of inherent optical
properties like the absorption or scattering coefficient. Current methods to observe the ocean’s optical
properties include underwater optical sensors as well as airborne and satellite observations. These sensors
passively measure sunlight backscattered from the upper layers of the ocean. Active sensors equipped with
various light sources, including lasers of different colours and filters, are also used to probe the vertical
distribution and composition of dissolved and particulate matter and the depth of coastal waters.