### PR TITLE
use `npm ci` in deployment/testing

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: ./test
-      run: npm install
+      run: npm ci --quiet
 
     - name: Test frontend loads without errors
       working-directory: ./test

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ ARG API_URL
 ENV API_URL $API_URL
 
 COPY . .
-RUN npm install --quiet
+RUN npm ci --quiet
 RUN npm run build
 
 # Stage 2 - the production environment

--- a/web-api/Dockerfile
+++ b/web-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:alpine
 WORKDIR /usr/src/app
 COPY . .
-RUN npm install --quiet
+RUN npm ci --quiet
 CMD ["node", "./bin/www"]


### PR DESCRIPTION
Switch to using `npm ci` for deployment/testing

https://docs.npmjs.com/cli/v8/commands/npm-ci

Thx for the tip, @steviewanders 