### PR TITLE
handle EDDTableFromErddap redirects

### DIFF
--- a/scraper/erddap_scraper/ERDDAP.py
+++ b/scraper/erddap_scraper/ERDDAP.py
@@ -91,8 +91,6 @@ class ERDDAP(object):
         url_combined = self.url + url
         logger.debug(unquote(url_combined))
 
-        # response = self.session.get(url_combined)
-
         response = None
         if self.cache_requests:
             cache = self.cache
@@ -104,6 +102,15 @@ class ERDDAP(object):
                 cache[url_combined] = response
         else:
             response = self.session.get(url_combined)
+            original_hostname = urlparse(url_combined).hostname
+            actual_hostname = urlparse(response.url).hostname
+
+            if original_hostname != actual_hostname:
+                # redirect due to EDDTableFromErddap
+                self.url = response.url.split("/erddap")[0] + "/erddap"
+                self.logger.debug(
+                    "Redirecting " + original_hostname + "to" + actual_hostname
+                )
 
         no_data = False
         # Newer erddaps respond with 404 for no data

--- a/scraper/erddap_scraper/__main__.py
+++ b/scraper/erddap_scraper/__main__.py
@@ -147,12 +147,17 @@ def main(erddap_urls, cache_requests, folder):
 
     print("Adding", len(datasets), "datasets and", len(profiles), "profiles")
 
-    datasets.to_csv(datasets_file, index=False)
-    profiles.to_csv(profiles_file, index=False)
-    variables.to_csv(variables_file, index=False)
+    # drop duplicates caused by EDDTableFromErddap redirects
+    datasets.drop_duplicates(["erddap_url", "dataset_id"]).to_csv(
+        datasets_file, index=False
+    )
+    profiles.drop_duplicates().to_csv(profiles_file, index=False)
+    variables.drop_duplicates().to_csv(variables_file, index=False)
     df_ckan.to_csv(ckan_file, index=False)
-    skipped_datasets.to_csv(skipped_datasets_file, index=False)
-    df_cde_eov_to_standard_name.to_csv("df_cde_eov_to_standard_name.csv", index=False)
+    skipped_datasets.drop_duplicates().to_csv(skipped_datasets_file, index=False)
+    df_cde_eov_to_standard_name.drop_duplicates().to_csv(
+        "df_cde_eov_to_standard_name.csv", index=False
+    )
     print(
         "Wrote",
         datasets_file,

--- a/scraper/erddap_scraper/dataset.py
+++ b/scraper/erddap_scraper/dataset.py
@@ -40,7 +40,7 @@ class Dataset(object):
             {
                 "title": [self.globals["title"]],
                 "summary": [self.globals["summary"]],
-                "erddap_url": [self.erddap_url],
+                "erddap_url": [self.erddap_server.url],
                 "dataset_id": [self.id],
                 "cdm_data_type": [self.cdm_data_type],
                 "platform": [self.platform],
@@ -189,7 +189,7 @@ class Dataset(object):
         return df_count
 
     def get_data_access_form_url(self):
-        return self.erddap_url + "/tabledap/" + self.id + ".html"
+        return self.erddap_server.url + "/tabledap/" + self.id + ".html"
 
     def get_eovs(self):
         eovs = []
@@ -252,7 +252,7 @@ class Dataset(object):
             }
         )
 
-        df_variables["erddap_url"] = self.erddap_url
+        df_variables["erddap_url"] = self.erddap_server.url
         df_variables["dataset_id"] = self.id
         df_global = df.query('`Variable Name`=="NC_GLOBAL"')[
             ["Attribute Name", "Value"]


### PR DESCRIPTION
Handles datasets that are redirected (Eg most cioosatlantic.ca/erddap datasets are actually hosted at smartatlantic.ca/erddap, so we currently duplicate their datasets)

fixes #184