### PR TITLE
adds platform groupings

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,9 +1,8 @@
 name: Test
 
 on:
+  push:
   pull_request:
-    branches:
-    - master
 
 jobs:
   docker:

--- a/harvester/cde_harvester/dataset.py
+++ b/harvester/cde_harvester/dataset.py
@@ -229,7 +229,7 @@ class Dataset(object):
             try:
                 l06_platform_label = platforms_nerc_ioos.query(
                     f"ioos_label=='{platform}'"
-                )["l06_label"].item()
+                )["category"].item()
 
                 return l06_platform_label
 
@@ -237,10 +237,16 @@ class Dataset(object):
                 self.logger.debug("Found unsupported IOOS platform:", platform)
 
         if "L06" in platform_vocabulary:
+            platforms_nerc_ioos_no_duplicates = platforms_nerc_ioos.drop_duplicates(
+                subset=["l06_label"]
+            )
+
             if platform in list(platforms_nerc_ioos["l06_label"]):
-                return platform
+                return platforms_nerc_ioos_no_duplicates.query(
+                    f"l06_label=='{platform}'"
+                )["category"].item()
             else:
-                self.logger.debug("Found unsupported L06 platform:", platform)
+                self.logger.debug("Found unsupported L06 platform: " + platform)
 
     def get_metadata(self):
         "get all the global and variable metadata for a dataset"

--- a/harvester/cde_harvester/platform_ioos_to_l06.py
+++ b/harvester/cde_harvester/platform_ioos_to_l06.py
@@ -12,12 +12,36 @@ CDE converts IOOS to L06 using a mapping found here:  https://mmisw.org/ont?iri=
 
 
 def get_l06_codes_and_labels():
-    # parse NERC L06 to verify platform labels and map to IOOS
-    url = "http://vocab.nerc.ac.uk/collection/L06/current/?_profile=dd&_mediatype=application/json"
-    df = pd.read_json(url)
-    df["l06_code"] = df.apply(lambda x: x["uri"].split("/")[-2], axis=1)
-    df = df[["l06_code", "prefLabel"]].set_index("l06_code")
-    df.rename(columns={"prefLabel": "l06_label"}, inplace=True)
+
+    url = "http://vocab.nerc.ac.uk/collection/L06/current/?_profile=nvs&_mediatype=application/ld+json"
+    platforms = requests.get(url).json()["@graph"]
+
+    platforms_parsed = {}
+    l06Lookup = {}
+
+    for platform in platforms:
+        # first entry describes the vocabulary, skip it
+        if not "identifier" in platform:
+            continue
+
+        label = platform["prefLabel"]["@value"]
+        broader = platform.get("broader", [])
+        id = platform["@id"]
+
+        for url in broader:
+            if "L06" in url:
+                platforms_parsed[id] = {"broader_L06_url": url, "l06_label": label}
+        l06Lookup[id] = label
+
+    for l06_url_code, item in platforms_parsed.items():
+        broaderL06 = item["broader_L06_url"]
+        res = l06Lookup[broaderL06]
+        platforms_parsed[l06_url_code]["category"] = res
+
+    df = pd.DataFrame.from_dict(platforms_parsed, orient="index")
+    del df["broader_L06_url"]
+    df.index = df.index.str.split("/").str[-2]
+    df.index.names = ["l06_code"]
     return df
 
 


### PR DESCRIPTION
turns out Seavox platform categories (L06) has inherent groupings. We can use the parent term (Eg mooring, float) instead of the child term so that we can have simpler options in the UI