### PR TITLE
increase dataset download limit to 1GB

### DIFF
--- a/downloader/erddap_downloader/download_erddap.py
+++ b/downloader/erddap_downloader/download_erddap.py
@@ -16,7 +16,7 @@ from erddapy import ERDDAP
 from shapely.geometry import Point
 
 ONE_MB = 10 ** 6
-DATASET_SIZE_LIMIT = 100 * ONE_MB
+DATASET_SIZE_LIMIT = 1000 * ONE_MB
 QUERY_SIZE_LIMIT = 5000 * ONE_MB
 
 DOWNLOADING = "DOWNLOADING"


### PR DESCRIPTION
Increases download size limit in the backend. I will merge to version1 branch as well. By increasing this limit we can get more data on what size of downloads users typically need

Limits are now:
1Gb per dataset
5GB total