### PR TITLE
handle datasets with platform without platform_vocabulary

### DIFF
--- a/harvester/cde_harvester/dataset.py
+++ b/harvester/cde_harvester/dataset.py
@@ -252,6 +252,9 @@ class Dataset(object):
         platform_vocabulary = self.globals.get("platform_vocabulary")
 
         if not (platform and platform_vocabulary):
+            self.logger.debug(
+                "Found platform without platform_vocabulary, setting platform to 'unknown'"
+            )
             return "unknown"
 
         if "ioos" in platform_vocabulary:

--- a/harvester/cde_harvester/dataset.py
+++ b/harvester/cde_harvester/dataset.py
@@ -252,7 +252,7 @@ class Dataset(object):
         platform_vocabulary = self.globals.get("platform_vocabulary")
 
         if not (platform and platform_vocabulary):
-            return None
+            return "unknown"
 
         if "ioos" in platform_vocabulary:
             try:


### PR DESCRIPTION
`platform` is required to be `not null`  in the database and this line was returning None for the case when `platform` is given in the metadata with `platform_vocabulary` populated.

"unknown" is what is used in other places for datasets without platform info