### PR TITLE
add plausible to frontend to track page views

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,6 +10,8 @@
   <script crossorigin src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
   <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.33.1/plotly-basic.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-plotly.js@1.0.2/dist/create-plotly-component.js"></script>
+  <script defer data-domain="explore.cioos.ca" src="https://plausible.server.cioospacific.ca/js/script.hash.outbound-links.js"></script>
+  <script defer data-domain="all.cioos.ca" src="https://plausible.server.cioospacific.ca/js/script.js"></script>
 
   <meta charset="UTF-8">
   <title>CIOOS Data Explorer</title>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,7 +10,7 @@
   <script crossorigin src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
   <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/1.33.1/plotly-basic.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-plotly.js@1.0.2/dist/create-plotly-component.js"></script>
-  <script defer data-domain="explore.cioos.ca" src="https://plausible.server.cioospacific.ca/js/script.hash.outbound-links.js"></script>
+  <script defer data-domain="explore.cioos.ca" src="https://plausible.server.cioospacific.ca/js/script.hash.outbound-links.local.js"></script>
   <script defer data-domain="all.cioos.ca" src="https://plausible.server.cioospacific.ca/js/script.js"></script>
 
   <meta charset="UTF-8">

--- a/harvester/setup.py
+++ b/harvester/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"": ["cde_to_goos_eov.json", "goos_eov_to_standard_name.json"]},
     install_requires=[
         "requests",
-        "pandas",
+        "pandas<2.0.0",
         "erddapy",
         "shapely",
         "sqlalchemy",


### PR DESCRIPTION
Related to #414 this PR add plausible to explore.cioos.ca. The views will cumulated within:

1. With all.cioos.ca : https://plausible.server.cioospacific.ca/all.cioos.ca
2. Explore.cioos.ca  only: https://plausible.server.cioospacific.ca/explore.cioos.ca

The explore.cioos.ca has also the the outbound-link script and hash scripts. The latest may give the abiiity to track users views on the page and the different filters used which are affecting the url.